### PR TITLE
Add markdown header styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ## [0.0.3]
 ### Added
 - Colors for editor
+
+## [0.1.0]
+### Added
+- Styling for markdown headers

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "monokai-light",
     "displayName": "Monokai Light",
     "description": "Monokai Light Theme",
-    "version": "0.0.3",
+    "version": "0.1.0",
     "publisher": "zoxon",
     "engines": {
         "vscode": "^1.12.0"

--- a/themes/Monokai Light Theme-color-theme.json
+++ b/themes/Monokai Light Theme-color-theme.json
@@ -248,6 +248,13 @@
 			}
 		},
 		{
+			"name": "Markup Headings",
+			"scope": "markup.heading",
+			"settings": {
+				"foreground": "#cf7000"
+			}
+		},
+		{
 			"name": "Markup Setext Header",
 			"scope": "markup.heading.setext",
 			"settings": {


### PR DESCRIPTION
I added style for markdown headers to the `Monokai Light Theme-color-theme.json` file. I also gave the extension a minor version bump in `package.json` and updated the changelog.

Ref: https://github.com/zoxon/vscode-theme-monokai-light/issues/2